### PR TITLE
Fixes for initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Follow these steps to set up your environment:
 
 You can then visit `localhost:4000/admin/posts` and see a Torch-generated admin.
 
-If you make a change to one of the generators, you can run `mix regenerate` inside `apps/example` to regenerate the Torch code.
+If you make a change to one of the generators, you can run `mix regenerate (eex|slim)` inside `apps/example` to regenerate the Torch code.

--- a/bin/setup
+++ b/bin/setup
@@ -21,5 +21,10 @@ cd apps/example && {
   cd -;
 }
 
+# workaround for https://github.com/npm/npm/issues/10343
+cd apps/torch && {
+  npm install;
+}
+
 mix test
 mix credo --strict


### PR DESCRIPTION
This PR addresses two issues related to first-time setup:

1) There is [a known issue with using `npm link`](https://github.com/npm/npm/issues/10343) that causes causes the `node_modules` directory of the linked package to get removed when another package installs it as a dependency. This was causing this step to fail...

> 2 In one terminal tab, cd `apps/torch` and run `./node_modules/brunch/bin/brunch watch --production`.

...because brunch had gotten blown away along with most of the other dependencies. The simplest workaround at this point is simply to run `npm install` again in `apps/torch` after running it in `apps/example`.

2) `mix regenerate` now requires the user to specify the output format (eex or slim) so I updated the README to reflect that.
