### PR TITLE
Remove prompt from boolean select field

### DIFF
--- a/apps/example/web/templates/admin/post/_form.html.eex
+++ b/apps/example/web/templates/admin/post/_form.html.eex
@@ -17,7 +17,7 @@
 
   <div class="field">
     <%= label f, :draft %>
-    <%= select f, :draft, [{"True", true}, {"False", false}], prompt: "Choose one" %>
+    <%= select f, :draft, [{"True", true}, {"False", false}] %>
     <%= error_tag f, :draft %>
   </div>
 

--- a/apps/torch/lib/mix/tasks/torch.gen.ex
+++ b/apps/torch/lib/mix/tasks/torch.gen.ex
@@ -204,7 +204,7 @@ defmodule Mix.Tasks.Torch.Gen do
     {label(key), ~s(= number_input f, #{inspect(key)}, step: "any"), error(key)}
   end
   defp do_input({key, :boolean}) do
-    {label(key), ~s(= select f, #{inspect(key)}, [{"True", true}, {"False", false}], prompt: "Choose one"), error(key)}
+    {label(key), ~s(= select f, #{inspect(key)}, [{"True", true}, {"False", false}]), error(key)}
   end
   defp do_input({key, :text}) do
     {label(key), ~s(= textarea f, #{inspect(key)}), error(key)}


### PR DESCRIPTION
This removes the "Choose one:" prompt when generating a boolean select field. This fixes issue #11. 

If you supply a `prompt` option to phoenix_html's `select` function, it always adds the prompt as an option with an empty value. This doesn't really make sense for a boolean, which should only be `true` or `false`, never blank.

@yulianglukhenko correctly points out that placeholders for select fields should be disabled, rather than having a blank value. That forces the user to make a selection which, for an optional field, is not what you want. Ideally, `select` would also take a `required` option that would either force the user to select an option, or allow the blank value. That would make a nice PR for phoenix_html. 
