### PR TITLE
Move app.js include to bottom of layout file

### DIFF
--- a/apps/example/web/static/css/_admin_variables.scss
+++ b/apps/example/web/static/css/_admin_variables.scss
@@ -6,7 +6,61 @@
 //     @import "admin_variables"
 //     @import "../../../node_modules/torch/web/static/css/torch"
 
-// $torch-primary-color: #043878;
-// $torch-secondary-color: #2097B8;
-// $torch-tertiary-color: #61ae24;
-// $torch-action-color: #2097B8;
+// Colors - http://www.colourlovers.com/palette/131576/Maddening_Caravan
+// $torch-primary-color: #ED303C;
+// $torch-secondary-color: #F5634A;
+// $torch-tertiary-color: #3B8183;
+
+// Typography
+// $torch-font-family: 'Open Sans', sans-serif;
+// $torch-heading-font-family: $torch-font-family;
+// $torch-hover-opacity: 0.7;
+
+// Font Sizes
+// $torch-small-font-size: 13px;
+// $torch-base-font-size: 14px;
+// $torch-font-size-large: 18px;
+// $torch-font-size-xxl: 48px;
+
+// Font Weight
+// $torch-light: 300;
+// $torch-regular: 400;
+// $torch-semibold: 600;
+// $torch-bold: 700;
+
+// Line height
+// $torch-line-height: 1.2;
+// $torch-heading-line-height: $torch-line-height;
+
+// Other Sizes
+// $torch-border-radius: 0px;
+// $torch-base-spacing: $torch-line-height * 1em;
+// $torch-small-spacing: $torch-base-spacing / 2;
+
+// Colors
+// $torch-placeholder-color: #999;
+// $torch-nav-primary-color: #ffffff;
+// $torch-toolbar-background-color: #f1f1f1;
+// $torch-table-font-color: #949494;
+// $torch-label-font-color: $torch-table-font-color;
+// $torch-th-font-color: $torch-nav-primary-color;
+
+// Font Colors
+// $torch-base-font-color: #333;
+// $torch-action-color: #3B8183;
+
+// Border
+// $torch-border-color: #D1D1D1;
+// $torch-border: 1px solid $torch-border-color;
+
+// Background Colors
+// $torch-base-background-color: #fff;
+
+// Forms
+// $torch-form-box-shadow: inset 0 1px 3px rgba(#000, 0.06);
+// $torch-form-box-shadow-focus: $torch-form-box-shadow, 0 0 5px adjust-color($torch-action-color, $lightness: -5%, $alpha: -0.3);
+// $torch-form-error-color: $torch-primary-color;
+
+// Animations
+// $torch-base-duration: 300ms;
+// $torch-base-timing: ease;

--- a/apps/example/web/templates/layout/admin.html.eex
+++ b/apps/example/web/templates/layout/admin.html.eex
@@ -1,7 +1,6 @@
 <html>
   <head>
     <title>Admin</title>
-    <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
   </head>
 
@@ -17,8 +16,8 @@
       </div>
 
       <header class="torch-main-header">
+        <h1>Torch Admin</h1>
         <nav>
-          <h1>Torch Admin</h1>
           <ul>
             <li><%= Torch.NavigationView.nav_link @conn, "Posts", admin_post_path(@conn, :index) %></a>
             <li><%= Torch.NavigationView.nav_link @conn, "Authors", admin_author_path(@conn, :index) %></li>
@@ -31,5 +30,6 @@
     <section class="torch">
       <%= render @view_module, @view_template, assigns %>
     </section>
+    <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>

--- a/apps/torch/priv/templates/eex/layout.eex.eex
+++ b/apps/torch/priv/templates/eex/layout.eex.eex
@@ -1,7 +1,6 @@
 <html>
   <head>
     <title>Admin</title>
-    <script src="<%%= static_path(@conn, "/js/app.js") %>"></script>
     <link rel="stylesheet" href="<%%= static_path(@conn, "/css/app.css") %>">
   </head>
 
@@ -29,5 +28,6 @@
     <section class="torch">
       <%%= render @view_module, @view_template, assigns %>
     </section>
+    <script src="<%%= static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>

--- a/apps/torch/priv/templates/slim/layout.slim.eex
+++ b/apps/torch/priv/templates/slim/layout.slim.eex
@@ -1,7 +1,6 @@
 html
   head
     title Admin
-    script src="#{static_path(@conn, "/js/app.js")}"
     link rel="stylesheet" href="#{static_path(@conn, "/css/app.css")}"
 
   body
@@ -20,3 +19,5 @@ html
 
     section.torch
       = render @view_module, @view_template, assigns
+
+    script src="#{static_path(@conn, "/js/app.js")}"


### PR DESCRIPTION
This moves the `<script>` tag to the bottom of the layout file, per convention, and fixes issue #12 

I also regenerated the files in the example app, which picked up a few other changes that had been made since the last time they were generated (e.g. `admin_variables.scss`).
