### PR TITLE
Restrict pagination links to groups of 10

### DIFF
--- a/apps/torch/lib/torch/templates/pagination/_pagination.html.eex
+++ b/apps/torch/lib/torch/templates/pagination/_pagination.html.eex
@@ -1,9 +1,10 @@
+<% distance = Map.get(@conn.assigns, :distance, 5) %>
 <ul class="pagination">
   <li>
     <%= prev_link(@page_number, @total_pages) %>
   </li>
   <%= if @total_pages > 1 do %>
-    <%= for num <- 1..@total_pages do %>
+    <%= for num <- start_page(@page_number, distance)..end_page(@page_number, @total_pages, distance) do %>
       <li>
         <a href="?<%= querystring(@conn, page: num) %>" class="<%= if @page_number == num, do: "active", else: "" %>">
           <%= num %>

--- a/apps/torch/lib/torch/views/pagination_view.ex
+++ b/apps/torch/lib/torch/views/pagination_view.ex
@@ -45,4 +45,24 @@ defmodule Torch.PaginationView do
       link "Next >", to: "?page=#{current_page + 1}"
     end
   end
+
+  defp start_page(current_page, distance) when current_page - distance < 1 do
+    current_page - (distance + (current_page - distance - 1))
+  end
+  defp start_page(current_page, distance) do
+    current_page - distance
+  end
+
+  defp end_page(current_page, 0, _distance) do
+    current_page
+  end
+  defp end_page(current_page, _total, distance) when current_page <= distance do
+    distance * 2
+  end
+  defp end_page(current_page, total, distance) when current_page + distance >= total do
+    total
+  end
+  defp end_page(current_page, _total, distance) do
+    current_page + distance - 1
+  end
 end

--- a/apps/torch/priv/templates/elixir/controller.ex
+++ b/apps/torch/priv/templates/elixir/controller.ex
@@ -18,6 +18,7 @@ defmodule <%= module %>Controller do
   @filtrex []
 <% end %>
   @pagination [page_size: 10]
+  @pagination_distance 5
 
   def index(conn, params) do
     {:ok, filter} = Filtrex.parse_params(@filtrex, params["<%= singular %>"] || %{})
@@ -33,7 +34,8 @@ defmodule <%= module %>Controller do
       page_number: page.page_number,
       page_size: page.page_size,
       total_pages: page.total_pages,
-      total_entries: page.total_entries
+      total_entries: page.total_entries,
+      distance: @pagination_distance
   end
 
   def new(conn, _params) do


### PR DESCRIPTION
Fixes #19 by adding Google-style pagination links: the number of pagination links is restricted by a `distance` setting, with the current page placed (roughly) in the center.

<img width="650" alt="screen shot 2016-09-19 at 6 28 19 am" src="https://cloud.githubusercontent.com/assets/21764/18633822/00deff28-7e33-11e6-840a-85f3caf52631.png">

The `distance` setting can be configured in the controller, but the pagination template falls back to a default value of 5 if the value is not set. This is to preserve backward compatibility with pages generated by older versions of torch.
