### PR TITLE
Add test template

### DIFF
--- a/lib/mix/tasks/torch.gen.ex
+++ b/lib/mix/tasks/torch.gen.ex
@@ -94,7 +94,6 @@ defmodule Mix.Tasks.Torch.Gen do
     binding = binding ++ [plural: plural,
                           attrs: attrs,
                           params: params(attrs),
-                          sample_id: 42,
                           configs: configs(attrs),
                           namespace: namespace,
                           namespace_underscore: namespace_underscore,
@@ -281,6 +280,16 @@ defmodule Mix.Tasks.Torch.Gen do
   end
 
   defp params(attrs) do
-    %{}
+    attrs
+    |> Enum.map(fn {field, type} -> {field, value(type)} end)
+    |> Enum.reject(fn {_field, value} -> value == nil end)
+    |> Enum.reduce(%{}, fn ({field, value}, params) -> Map.merge(params, %{field => value}) end)
   end
+
+  defp value(:boolean), do: true
+  defp value(:float), do: 42.0
+  defp value(:integer), do: 42
+  defp value(:string), do: "some content"
+  defp value(:text), do: "some content"
+  defp value(_), do: nil
 end

--- a/lib/mix/tasks/torch.gen.ex
+++ b/lib/mix/tasks/torch.gen.ex
@@ -93,6 +93,8 @@ defmodule Mix.Tasks.Torch.Gen do
     attrs = Mix.Torch.attrs(attrs)
     binding = binding ++ [plural: plural,
                           attrs: attrs,
+                          params: params(attrs),
+                          sample_id: 42,
                           configs: configs(attrs),
                           namespace: namespace,
                           namespace_underscore: namespace_underscore,
@@ -120,7 +122,8 @@ defmodule Mix.Tasks.Torch.Gen do
   defp copy_elixir(binding, path) do
     Mix.Torch.copy_from [:torch], "priv/templates/elixir", "", binding, [
       {:eex, "controller.ex", "web/controllers/#{path}_controller.ex"},
-      {:eex, "view.ex", "web/views/#{path}_view.ex"}
+      {:eex, "view.ex", "web/views/#{path}_view.ex"},
+      {:eex, "test.ex", "test/controllers/#{path}_controller_test.exs"}
     ]
     binding
   end
@@ -275,5 +278,9 @@ defmodule Mix.Tasks.Torch.Gen do
 
   defp error(field) do
     ~s(= error_tag f, #{inspect(field)})
+  end
+
+  defp params(attrs) do
+    %{}
   end
 end

--- a/lib/mix/tasks/torch.gen.ex
+++ b/lib/mix/tasks/torch.gen.ex
@@ -287,6 +287,8 @@ defmodule Mix.Tasks.Torch.Gen do
   end
 
   defp value(:boolean), do: true
+  defp value(:date), do: %{day: 17, month: 4, year: 2010}
+  defp value(:decimal), do: "42.0"
   defp value(:float), do: 42.0
   defp value(:integer), do: 42
   defp value(:string), do: "some content"

--- a/priv/templates/elixir/test.ex
+++ b/priv/templates/elixir/test.ex
@@ -27,12 +27,6 @@ defmodule <%= module %>ControllerTest do
     assert html_response(conn, 400) =~ "New <%= String.capitalize(singular) %>"
   end
 
-  test "renders page not found when id is nonexistent", %{conn: conn} do
-    assert_error_sent 404, fn ->
-      get conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :show, <%= sample_id %>)
-    end
-  end
-
   test "renders form for editing chosen resource", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
     conn = get conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :edit, <%= singular %>)

--- a/priv/templates/elixir/test.ex
+++ b/priv/templates/elixir/test.ex
@@ -1,5 +1,5 @@
 defmodule <%= module %>ControllerTest do
-  alias <%= module %>
+  alias <%= base %>.<%= String.capitalize(singular) %>
 
   use <%= base %>.ConnCase
 

--- a/priv/templates/elixir/test.ex
+++ b/priv/templates/elixir/test.ex
@@ -24,7 +24,7 @@ defmodule <%= module %>ControllerTest do
 
   test "does not create resource and renders errors when data is invalid", %{conn: conn} do
     conn = post conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :create), <%= singular %>: @invalid_attrs
-    assert html_response(conn, 200) =~ "New <%= singular %>"
+    assert html_response(conn, 400) =~ "New <%= String.capitalize(singular) %>"
   end
 
   test "shows chosen resource", %{conn: conn} do
@@ -48,14 +48,14 @@ defmodule <%= module %>ControllerTest do
   test "updates chosen resource and redirects when data is valid", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
     conn = put conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @valid_attrs
-    assert redirected_to(conn) == <%= namespace_underscore %>_<%= singular %>_path(conn, :show, <%= singular %>)
+    assert redirected_to(conn) == <%= namespace_underscore %>_<%= singular %>_path(conn, :index)
     assert Repo.get_by(<%= alias %>, @valid_attrs)
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
     conn = put conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @invalid_attrs
-    assert html_response(conn, 200) =~ "Edit <%= singular %>"
+    assert html_response(conn, 400) =~ "Edit <%= String.capitalize(singular) %>"
   end
 
   test "deletes chosen resource", %{conn: conn} do

--- a/priv/templates/elixir/test.ex
+++ b/priv/templates/elixir/test.ex
@@ -13,7 +13,7 @@ defmodule <%= module %>ControllerTest do
 
   test "renders form for new resources", %{conn: conn} do
     conn = get conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :new)
-    assert html_response(conn, 200) =~ "New <%= singular %>"
+    assert html_response(conn, 200) =~ "New <%= String.capitalize(singular) %>"
   end
 
   test "creates resource and redirects when data is valid", %{conn: conn} do
@@ -27,12 +27,6 @@ defmodule <%= module %>ControllerTest do
     assert html_response(conn, 400) =~ "New <%= String.capitalize(singular) %>"
   end
 
-  test "shows chosen resource", %{conn: conn} do
-    <%= singular %> = Repo.insert! %<%= alias %>{}
-    conn = get conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :show, <%= singular %>)
-    assert html_response(conn, 200) =~ "Show <%= singular %>"
-  end
-
   test "renders page not found when id is nonexistent", %{conn: conn} do
     assert_error_sent 404, fn ->
       get conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :show, <%= sample_id %>)
@@ -42,7 +36,7 @@ defmodule <%= module %>ControllerTest do
   test "renders form for editing chosen resource", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
     conn = get conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :edit, <%= singular %>)
-    assert html_response(conn, 200) =~ "Edit <%= singular %>"
+    assert html_response(conn, 200) =~ "Edit <%= String.capitalize(singular) %>"
   end
 
   test "updates chosen resource and redirects when data is valid", %{conn: conn} do

--- a/priv/templates/elixir/test.ex
+++ b/priv/templates/elixir/test.ex
@@ -1,0 +1,67 @@
+defmodule <%= module %>ControllerTest do
+  alias <%= module %>
+
+  use <%= base %>.ConnCase
+
+  @valid_attrs <%= inspect params %>
+  @invalid_attrs %{}
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, <%= singular %>_path(conn, :index)
+    assert html_response(conn, 200) =~ "<%= String.capitalize(plural) %>"
+  end
+
+  test "renders form for new resources", %{conn: conn} do
+    conn = get conn, <%= singular %>_path(conn, :new)
+    assert html_response(conn, 200) =~ "New <%= singular %>"
+  end
+
+  test "creates resource and redirects when data is valid", %{conn: conn} do
+    conn = post conn, <%= singular %>_path(conn, :create), <%= singular %>: @valid_attrs
+    assert redirected_to(conn) == <%= singular %>_path(conn, :index)
+    assert Repo.get_by(<%= alias %>, @valid_attrs)
+  end
+
+  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+    conn = post conn, <%= singular %>_path(conn, :create), <%= singular %>: @invalid_attrs
+    assert html_response(conn, 200) =~ "New <%= singular %>"
+  end
+
+  test "shows chosen resource", %{conn: conn} do
+    <%= singular %> = Repo.insert! %<%= alias %>{}
+    conn = get conn, <%= singular %>_path(conn, :show, <%= singular %>)
+    assert html_response(conn, 200) =~ "Show <%= singular %>"
+  end
+
+  test "renders page not found when id is nonexistent", %{conn: conn} do
+    assert_error_sent 404, fn ->
+      get conn, <%= singular %>_path(conn, :show, <%= sample_id %>)
+    end
+  end
+
+  test "renders form for editing chosen resource", %{conn: conn} do
+    <%= singular %> = Repo.insert! %<%= alias %>{}
+    conn = get conn, <%= singular %>_path(conn, :edit, <%= singular %>)
+    assert html_response(conn, 200) =~ "Edit <%= singular %>"
+  end
+
+  test "updates chosen resource and redirects when data is valid", %{conn: conn} do
+    <%= singular %> = Repo.insert! %<%= alias %>{}
+    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @valid_attrs
+    assert redirected_to(conn) == <%= singular %>_path(conn, :show, <%= singular %>)
+    assert Repo.get_by(<%= alias %>, @valid_attrs)
+  end
+
+  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+    <%= singular %> = Repo.insert! %<%= alias %>{}
+    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @invalid_attrs
+    assert html_response(conn, 200) =~ "Edit <%= singular %>"
+  end
+
+  test "deletes chosen resource", %{conn: conn} do
+    <%= singular %> = Repo.insert! %<%= alias %>{}
+    conn = delete conn, <%= singular %>_path(conn, :delete, <%= singular %>)
+    assert redirected_to(conn) == <%= singular %>_path(conn, :index)
+    refute Repo.get(<%= alias %>, <%= singular %>.id)
+  end
+end

--- a/priv/templates/elixir/test.ex
+++ b/priv/templates/elixir/test.ex
@@ -7,61 +7,61 @@ defmodule <%= module %>ControllerTest do
   @invalid_attrs %{}
 
   test "lists all entries on index", %{conn: conn} do
-    conn = get conn, <%= singular %>_path(conn, :index)
+    conn = get conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :index)
     assert html_response(conn, 200) =~ "<%= String.capitalize(plural) %>"
   end
 
   test "renders form for new resources", %{conn: conn} do
-    conn = get conn, <%= singular %>_path(conn, :new)
+    conn = get conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :new)
     assert html_response(conn, 200) =~ "New <%= singular %>"
   end
 
   test "creates resource and redirects when data is valid", %{conn: conn} do
-    conn = post conn, <%= singular %>_path(conn, :create), <%= singular %>: @valid_attrs
-    assert redirected_to(conn) == <%= singular %>_path(conn, :index)
+    conn = post conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :create), <%= singular %>: @valid_attrs
+    assert redirected_to(conn) == <%= namespace_underscore %>_<%= singular %>_path(conn, :index)
     assert Repo.get_by(<%= alias %>, @valid_attrs)
   end
 
   test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, <%= singular %>_path(conn, :create), <%= singular %>: @invalid_attrs
+    conn = post conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :create), <%= singular %>: @invalid_attrs
     assert html_response(conn, 200) =~ "New <%= singular %>"
   end
 
   test "shows chosen resource", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
-    conn = get conn, <%= singular %>_path(conn, :show, <%= singular %>)
+    conn = get conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :show, <%= singular %>)
     assert html_response(conn, 200) =~ "Show <%= singular %>"
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do
     assert_error_sent 404, fn ->
-      get conn, <%= singular %>_path(conn, :show, <%= sample_id %>)
+      get conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :show, <%= sample_id %>)
     end
   end
 
   test "renders form for editing chosen resource", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
-    conn = get conn, <%= singular %>_path(conn, :edit, <%= singular %>)
+    conn = get conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :edit, <%= singular %>)
     assert html_response(conn, 200) =~ "Edit <%= singular %>"
   end
 
   test "updates chosen resource and redirects when data is valid", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
-    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @valid_attrs
-    assert redirected_to(conn) == <%= singular %>_path(conn, :show, <%= singular %>)
+    conn = put conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @valid_attrs
+    assert redirected_to(conn) == <%= namespace_underscore %>_<%= singular %>_path(conn, :show, <%= singular %>)
     assert Repo.get_by(<%= alias %>, @valid_attrs)
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
-    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @invalid_attrs
+    conn = put conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit <%= singular %>"
   end
 
   test "deletes chosen resource", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
-    conn = delete conn, <%= singular %>_path(conn, :delete, <%= singular %>)
-    assert redirected_to(conn) == <%= singular %>_path(conn, :index)
+    conn = delete conn, <%= namespace_underscore %>_<%= singular %>_path(conn, :delete, <%= singular %>)
+    assert redirected_to(conn) == <%= namespace_underscore %>_<%= singular %>_path(conn, :index)
     refute Repo.get(<%= alias %>, <%= singular %>.id)
   end
 end


### PR DESCRIPTION
I took a first stab at taking tests. It is by no means exhaustive and only tests the index action without any filtering, and the create, update and delete actions, but it's a start. This pull request will add a test template to the generator. Please review.