### PR TITLE
Add ability to set default sort order

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,16 @@ npm: {
 Run `mix torch.gen (eex|slim)` to generate admin controllers and views for a given Ecto schema module. Torch expects you to have already defined the schema in your project.
 Also, Torch expects you to have `phoenix_slime` installed and configured if you generate `slim` templates.
 
+The full format is as follows:
+
+`mix torch.gen (eex|slim) [Admin | term for admin] [Singular
+model term] [plural model term] (sort field) (sort_direction)
+(attribute:attribute type)`
+
 For example, if we wanted to generate an admin area for a `Post` model we already have using `eex` templates, we could run this command:
 
 ```bash
-$ mix torch.gen eex Admin Post posts title:string body:text inserted_at:date
+$ mix torch.gen eex Admin Post posts inserted_at desc title:string body:text inserted_at:date
 ```
 
 And the output would be:

--- a/lib/mix/tasks/torch.gen.ex
+++ b/lib/mix/tasks/torch.gen.ex
@@ -85,13 +85,17 @@ defmodule Mix.Tasks.Torch.Gen do
   @doc false
   def run(args) do
     Mix.Task.run("app.start", [])
-    {_opts, [format, namespace, singular, plural | attrs], _} = OptionParser.parse(args, switches: [])
+    {_opts, [format, namespace, singular, plural, sort_field, sort_direction | attrs], _} = OptionParser.parse(args, switches: [])
 
     namespace_underscore = Macro.underscore(namespace)
     binding = Mix.Torch.inflect(namespace, singular)
+    sort_field = sort_field || "id"
+    sort_direction = sort_direction || "desc"
     path = namespace_underscore <> "/" <> binding[:path]
     attrs = Mix.Torch.attrs(attrs)
     binding = binding ++ [plural: plural,
+                          sort_field: sort_field,
+                          sort_direction: sort_direction,
                           attrs: attrs,
                           params: params(attrs),
                           configs: configs(attrs),

--- a/lib/mix/tasks/torch.gen.ex
+++ b/lib/mix/tasks/torch.gen.ex
@@ -85,9 +85,8 @@ defmodule Mix.Tasks.Torch.Gen do
   @doc false
   def run(args) do
     Mix.Task.run("app.start", [])
-    { _opts,
-      [
-        format,
+    {_opts,
+      [format,
         namespace,
         singular,
         plural,

--- a/lib/mix/tasks/torch.gen.ex
+++ b/lib/mix/tasks/torch.gen.ex
@@ -85,7 +85,19 @@ defmodule Mix.Tasks.Torch.Gen do
   @doc false
   def run(args) do
     Mix.Task.run("app.start", [])
-    {_opts, [format, namespace, singular, plural, sort_field, sort_direction | attrs], _} = OptionParser.parse(args, switches: [])
+    { _opts,
+      [
+        format,
+        namespace,
+        singular,
+        plural,
+        sort_field,
+        sort_direction
+        |
+        attrs
+      ],
+      _
+    } = OptionParser.parse(args, switches: [])
 
     namespace_underscore = Macro.underscore(namespace)
     binding = Mix.Torch.inflect(namespace, singular)

--- a/lib/torch/templates/pagination/_pagination.html.eex
+++ b/lib/torch/templates/pagination/_pagination.html.eex
@@ -6,7 +6,7 @@
   <%= if @total_pages > 1 do %>
     <%= for num <- start_page(@page_number, distance)..end_page(@page_number, @total_pages, distance) do %>
       <li>
-        <a href="?<%= querystring(@conn, page: num) %>" class="<%= if @page_number == num, do: "active", else: "" %>">
+        <a href="?<%= querystring( @conn, page: num, sort_opts: sort_opts(@conn.assigns) ) %>" class="<%= if @page_number == num, do: "active", else: "" %>">
           <%= num %>
         </a>
       </li>

--- a/lib/torch/views/pagination_view.ex
+++ b/lib/torch/views/pagination_view.ex
@@ -20,9 +20,9 @@ defmodule Torch.PaginationView do
       prev_link(1, 1)
       # => returns nil
   """
-  def prev_link(conn, current_page, _num_pages) do
+  def prev_link(conn, current_page, _num_pages, sort_opts \\ nil ) do
     if current_page != 1 do
-      link "< Prev", to: "?" <> querystring(conn, page: current_page - 1)
+      link "< Prev", to: "?" <> querystring(conn, page: current_page - 1, sort_opts: sort_opts)
     end
   end
 
@@ -37,9 +37,9 @@ defmodule Torch.PaginationView do
       next_link(2, 2)
       # => returns nil
   """
-  def next_link(conn, current_page, num_pages) do
+  def next_link(conn, current_page, num_pages, sort_opts \\ nil) do
     if current_page != num_pages do
-      link "Next >", to: "?" <> querystring(conn, page: current_page + 1)
+      link "Next >", to: "?" <> querystring(conn, page: current_page + 1, sort_opts: sort_opts)
     end
   end
 
@@ -62,5 +62,12 @@ defmodule Torch.PaginationView do
   end
   defp end_page(current_page, _total, distance) do
     current_page + distance - 1
+  end
+  
+  defp sort_opts(%{ sort_field: sort_field, sort_direction: sort_direction }) do
+    %{
+      sort_field: sort_field,
+      sort_direction: sort_direction
+    }
   end
 end

--- a/lib/torch/views/pagination_view.ex
+++ b/lib/torch/views/pagination_view.ex
@@ -64,10 +64,8 @@ defmodule Torch.PaginationView do
     current_page + distance - 1
   end
 
-  defp sort_opts(%{ sort_field: sort_field, sort_direction: sort_direction}) do
-    %{
-      sort_field: sort_field,
-      sort_direction: sort_direction
-    }
+  defp sort_opts(%{sort_field: sort_field, sort_direction: sort_direction}) do
+    %{sort_field: sort_field,
+      sort_direction: sort_direction}
   end
 end

--- a/lib/torch/views/pagination_view.ex
+++ b/lib/torch/views/pagination_view.ex
@@ -20,7 +20,7 @@ defmodule Torch.PaginationView do
       prev_link(1, 1)
       # => returns nil
   """
-  def prev_link(conn, current_page, _num_pages, sort_opts \\ nil ) do
+  def prev_link(conn, current_page, _num_pages, sort_opts \\ nil) do
     if current_page != 1 do
       link "< Prev", to: "?" <> querystring(conn, page: current_page - 1, sort_opts: sort_opts)
     end
@@ -63,8 +63,8 @@ defmodule Torch.PaginationView do
   defp end_page(current_page, _total, distance) do
     current_page + distance - 1
   end
-  
-  defp sort_opts(%{ sort_field: sort_field, sort_direction: sort_direction }) do
+
+  defp sort_opts(%{ sort_field: sort_field, sort_direction: sort_direction}) do
     %{
       sort_field: sort_field,
       sort_direction: sort_direction

--- a/lib/torch/views/table_view.ex
+++ b/lib/torch/views/table_view.ex
@@ -66,12 +66,14 @@ defmodule Torch.TableView do
     original = URI.decode_query(conn.query_string)
     opts = %{
       "page" => opts[:page],
-      "sort_field" => opts[:sort_field] || conn.params["sort_field"] || "id",
-      "sort_direction" => opts[:sort_direction] || conn.params["sort_direction"] || "asc"
+      "sort_field" => opts[:sort_field] || conn.params["sort_field"] || nil,
+      "sort_direction" => opts[:sort_direction] || conn.params["sort_direction"] || nil
     }
 
     original
     |> Map.merge(opts)
+    |> Enum.filter( fn{_, v} -> v != nil end )
+    |> Enum.into(%{})
     |> URI.encode_query
   end
 

--- a/lib/torch/views/table_view.ex
+++ b/lib/torch/views/table_view.ex
@@ -72,7 +72,7 @@ defmodule Torch.TableView do
 
     original
     |> Map.merge(opts)
-    |> Enum.filter( fn{_, v} -> v != nil end )
+    |> Enum.filter(fn{_, v} -> v != nil end)
     |> Enum.into(%{})
     |> URI.encode_query
   end

--- a/priv/templates/elixir/controller.ex
+++ b/priv/templates/elixir/controller.ex
@@ -21,8 +21,10 @@ defmodule <%= module %>Controller do
   @pagination_distance 5
 
   def index(conn, params) do
-    params = Map.put_new(params, "sort_direction", "<%= sort_direction %>")
-    params = Map.put_new(params, "sort_field", "<%= sort_field %>")
+    params =
+      params
+      |> Map.put_new("sort_direction", "<%= sort_direction %>")
+      |> Map.put_new("sort_field", "<%= sort_field %>")
     
     {:ok, sort_direction} = Map.fetch(params, "sort_direction")
     {:ok, sort_field} = Map.fetch(params, "sort_field")

--- a/priv/templates/elixir/controller.ex
+++ b/priv/templates/elixir/controller.ex
@@ -21,6 +21,11 @@ defmodule <%= module %>Controller do
   @pagination_distance 5
 
   def index(conn, params) do
+    params = Map.put_new(params, "sort_direction", "<%= sort_direction %>")
+    params = Map.put_new(params, "sort_field", "<%= sort_field %>")
+    
+    {:ok, sort_direction} = Map.fetch(params, "sort_direction")
+    {:ok, sort_field} = Map.fetch(params, "sort_field")
     {:ok, filter} = Filtrex.parse_params(@filtrex, params["<%= singular %>"] || %{})
 
     page =
@@ -35,7 +40,9 @@ defmodule <%= module %>Controller do
       page_size: page.page_size,
       total_pages: page.total_pages,
       total_entries: page.total_entries,
-      distance: @pagination_distance
+      distance: @pagination_distance,
+      sort_field: sort_field,
+      sort_direction: sort_direction
   end
 
   def new(conn, _params) do


### PR DESCRIPTION
The default sort order for a model in the admin can be set during generation. This is done by passing the sort field and sort direction as the last argument before the attributes when running `mix torch.gen`.

For example:
`mix torch.gen eex Admin Post posts inserted_at desc title:string body:text inserted_at:date`

Fixes #32 