### PR TITLE
package.json tweaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+var path = require("path");
+
+module.exports = {
+  includePaths: [
+    path.join(__dirname, "assets")
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./assets/js/app.js",
   "style": "./assets/css/app.sass",
   "files": [
-    "./assets/",
+    "./assets",
     "./priv/static",
     "./package.json",
     "./webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.2.0",
   "repository": {},
   "license": "MIT",
-  "main": "./priv/static/torch.js",
+  "main": "./assets/js/app.js",
+  "style": "./assets/css/app.sass",
   "files": [
+    "./assets/",
     "./priv/static",
     "./package.json",
     "./webpack.config.js",


### PR DESCRIPTION
* Add assets directory to files list so loaders can find it.
* Add style key pointing to entry point for css loaders.

Right now, the torch css can't be imported in sass via `@import "torch"`.

This change should ensure:

1. An application can import the 'uncompiled' assets properly. (To enable overriding variables)
2. An application does not need to specify a path when importing. e.g. `@import "torch/priv/static/torch.css"`

I'm not completely familiar with the `package.json` spec, so I may be missing something, however.

@codeithuman Please review at your convenience.