### PR TITLE
Fix start_page in pagination rendering

### DIFF
--- a/lib/torch/views/pagination_view.ex
+++ b/lib/torch/views/pagination_view.ex
@@ -47,6 +47,11 @@ defmodule Torch.PaginationView do
     end
   end
 
+  defp start_page(current_page, distance)
+      when current_page - distance <= 0 do
+    1
+  end
+
   defp start_page(current_page, distance) do
     current_page - distance
   end

--- a/test/torch/views/pagination_view_test.exs
+++ b/test/torch/views/pagination_view_test.exs
@@ -1,7 +1,33 @@
 defmodule Torch.PaginationViewTest do
+  @moduledoc false
   use ExUnit.Case
 
   import Phoenix.HTML, only: [safe_to_string: 1]
+  import Torch.PaginationView
 
   doctest Torch.PaginationView, import: true
+
+  describe "prev_link/4" do
+    test "when current page is 1" do
+      refute prev_link(%Plug.Conn{params: %{}}, 1)
+    end
+
+    test "when current page is more than 1" do
+      current_page = 2
+      link = prev_link(%Plug.Conn{params: %{}}, current_page) |> safe_to_string()
+      assert link =~ "?page=#{current_page - 1}"
+    end
+  end
+
+  describe "next_link/4" do
+    test "when current page is equal to num pages" do
+      refute next_link(%Plug.Conn{}, 2, 2)
+    end
+
+    test "when current page is more than num pages" do
+      current_page = 1
+      link = next_link(%Plug.Conn{params: %{}}, current_page, 2) |> safe_to_string()
+      assert link =~ "?page=#{current_page + 1}"
+    end
+  end
 end


### PR DESCRIPTION
We had a bug with pagination rendering:

<img width="592" alt="screenshot 2018-11-19 at 13 55 42" src="https://user-images.githubusercontent.com/238505/48703755-cb069d00-ec05-11e8-991f-c001da16380f.png">

The view doesn't implement a case when `current_page - distance <= 0` and this is a reason why we see negative numbers for pages.

This PR supposed to fix the described bug:

<img width="592" alt="screenshot 2018-11-19 at 14 11 44" src="https://user-images.githubusercontent.com/238505/48703974-6c8dee80-ec06-11e8-96db-ff6e29acaf07.png">

<img width="592" alt="screenshot 2018-11-19 at 14 11 50" src="https://user-images.githubusercontent.com/238505/48703980-6f88df00-ec06-11e8-844e-2b0ad9983749.png">

Also, it would be nice to have tests for `pagination_view.ex`.