### PR TITLE
Fix: Remove injected templates from priv

### DIFF
--- a/lib/mix/torch.ex
+++ b/lib/mix/torch.ex
@@ -75,6 +75,6 @@ defmodule Mix.Torch do
   end
 
   def remove_templates(template_dir) do
-    File.rm("priv/templates/#{template_dir}/")
+    File.rm_rf("priv/templates/#{template_dir}/")
   end
 end


### PR DESCRIPTION
The current code blocks users from using the standard Phoenix generators because the call to `File.rm` fails if the directory is not empty. The purpose of this line is to remove a non-empty directory, so we need to use something else.
