### PR TITLE
Properly backup and restore project templates for torch.gen.html task

### DIFF
--- a/lib/mix/tasks/torch.gen.html.ex
+++ b/lib/mix/tasks/torch.gen.html.ex
@@ -15,6 +15,9 @@ defmodule Mix.Tasks.Torch.Gen.Html do
   def run(args) do
     %{format: format} = Mix.Torch.parse_config!("torch.gen.html", args)
 
+    # First, backup the projects existing templates if they exist
+    Enum.each(@commands, &Mix.Torch.backup_project_templates/1)
+
     # Inject the torch templates for the generator into the priv/
     # directory so they will be picked up by the Phoenix generator
     Enum.each(@commands, &Mix.Torch.inject_templates(&1, format))
@@ -25,6 +28,9 @@ defmodule Mix.Tasks.Torch.Gen.Html do
     # Remove the injected templates from priv/ so they will not
     # affect future Phoenix generator commands
     Enum.each(@commands, &Mix.Torch.remove_templates/1)
+
+    # Restore the projects existing templates if present
+    Enum.each(@commands, &Mix.Torch.restore_project_templates/1)
 
     Mix.shell().info("""
     Ensure the following is added to your endpoint.ex:

--- a/lib/mix/torch.ex
+++ b/lib/mix/torch.ex
@@ -74,7 +74,15 @@ defmodule Mix.Torch do
     ])
   end
 
+  def backup_project_templates(mix_task_name) do
+    File.rename("priv/templates/#{mix_task_name}", "priv/templates/#{mix_task_name}_backup")
+  end
+
+  def restore_project_templates(mix_task_name) do
+    File.rename("priv/templates/#{mix_task_name}_backup", "priv/templates/#{mix_task_name}")
+  end
+
   def remove_templates(template_dir) do
-    File.rm("priv/templates/#{template_dir}/")
+    File.rm_rf("priv/templates/#{template_dir}/")
   end
 end


### PR DESCRIPTION
If the given Phoenix project had already customized
any of the `phx.gen.html` and/or `phx.gen.context`
templates, this change will properly retain those templates.

The `torch.gen.html` task will now backup the existing template
directories (if they exist) and restore them at the end of the
process.  After backing up the directories, Torch will create
and inject it's own custom template, and then clean up after
itself.

This change also fixes the previous `remove_templates` function
to actually remove the directories, as the previous iteration
left the directories in place.