### PR TITLE
Fixes pikaday date formating to YYYY-MM-DD

### DIFF
--- a/assets/js/torch.js
+++ b/assets/js/torch.js
@@ -117,8 +117,18 @@ window.onload = () => {
     })
   })
 
+  const formatDate = date =>
+        date
+        .toLocaleString('en-us', {year: 'numeric', month: '2-digit', day: '2-digit'})
+        .replace(/(\d+)\/(\d+)\/(\d+)/, '$3-$1-$2')
+
   slice.call(document.querySelectorAll('.datepicker'), 0).forEach((field) => {
-    new Pikaday({field: field, theme: 'torch-datepicker'})
+      new Pikaday({
+          field: field,
+          toString: date => formatDate(date),
+          onSelect: date => field.value = formatDate(date),
+          theme: 'torch-datepicker'
+      })
   })
 
   slice.call(document.querySelectorAll('.torch-flash-close'), 0).forEach((field) => {


### PR DESCRIPTION
This forces format of pikaday to always be YYYY-MM-DD.

There is a way to do the same without moment.js, but it seems broken now, so it would need master version of pikaday. More info in https://github.com/Pikaday/Pikaday/issues/870

PS. I didn't run webpack to generate the new packed js files.