### PR TITLE
[mix] Update uninstall task to mimic install

### DIFF
--- a/lib/mix/tasks/torch.uninstall.ex
+++ b/lib/mix/tasks/torch.uninstall.ex
@@ -1,6 +1,6 @@
 defmodule Mix.Tasks.Torch.Uninstall do
   @moduledoc """
-  Uninstalls torch layout & templates.
+  Uninstalls torch layout.
 
   ## Example
 
@@ -15,19 +15,6 @@ defmodule Mix.Tasks.Torch.Uninstall do
     %{format: format, otp_app: otp_app} = Mix.Torch.parse_config!("torch.uninstall", args)
 
     paths = [
-      "priv/templates/phx.gen.html/controller_test.exs",
-      "priv/templates/phx.gen.html/controller.ex",
-      "priv/templates/phx.gen.html/edit.html.#{format}",
-      "priv/templates/phx.gen.html/form.html.#{format}",
-      "priv/templates/phx.gen.html/index.html.#{format}",
-      "priv/templates/phx.gen.html/new.html.#{format}",
-      "priv/templates/phx.gen.html/show.html.#{format}",
-      "priv/templates/phx.gen.html/view.ex",
-      "priv/templates/phx.gen.context/access_no_schema.ex",
-      "priv/templates/phx.gen.context/context.ex",
-      "priv/templates/phx.gen.context/schema_access.ex",
-      "priv/templates/phx.gen.context/test_cases.exs",
-      "priv/templates/phx.gen.context/context_test.exs",
       "lib/#{otp_app}_web/templates/layout/torch.html.#{format}"
     ]
 


### PR DESCRIPTION
We should only uninstall the Torch layout file as
that is all that is created via the corresponding
install task.

The templates are cleaned up each time the `torch.gen.html`
task is run, so if we delete them here from this task,
we may be inadvertently deleting any customizations that the
user has done to the gen.html templates on their own.