### PR TITLE
Fix ordering of FilterView.find_param for :select

### DIFF
--- a/lib/torch/views/filter_view.ex
+++ b/lib/torch/views/filter_view.ex
@@ -268,7 +268,7 @@ defmodule Torch.FilterView do
   end
 
   defp find_param(params, field, :select) do
-    do_find_param(params, field, ~w(equals contains))
+    do_find_param(params, field, ~w(contains equals))
   end
 
   defp find_param(params, field, :date_select) do


### PR DESCRIPTION
Since the order of the options passed in to the function decide which
value is default, and the "string" input field defaults to "contains",
then the order of the `~w(equals contains)` options passed into
`do_find_param` needs to be switched to `~w(contains equals)`.

Alternatively, if the switch to `~w(equals contains)` was intentional,
the vale passed into `do_find_param` for `:string` should be `equals`
instead of `contains`.

Fixes issue #270 