### PR TITLE
fix matching for setting active navbar link

### DIFF
--- a/assets/js/torch.js
+++ b/assets/js/torch.js
@@ -54,10 +54,9 @@ window.onload = () => {
    */
   slice.call(document.querySelectorAll('.torch-nav a'), 0).forEach((field) => {
     const url = window.location.href
-    const linkTarget = field.getAttribute('href')
-    const regex = RegExp(linkTarget)
+    const linkTargetFullPath = new URL(field.getAttribute('href'), document.baseURI).href
 
-    if (regex.test(url)) {
+    if (url.startsWith(linkTargetFullPath)) {
       field.classList.add('active')
     }
   })


### PR DESCRIPTION
Quick fix for a minor visual issue where any link with a name that is a subset of the current active link will also be set as active, as the previous regex statement was matching anything that **contained** said string.

------------------

### Bug Example
 When "`developer_user`" is the active link, any tabs with a name contained in that string will also be highlighted, i.e. "`user`"
<img width="401" alt="image" src="https://user-images.githubusercontent.com/45409688/176956040-0c2eb173-81fb-4cb5-8925-44380ccd663f.png">


### Fix
Converts the navbar link into a full link path and compares against the current URL.

This should also work no-matter how the end-user defines their navbar link, be it:
```html
<a href="users">Users</a>
<a href="/users">Users</a>
<a href="some/path/users">Users</a>
<a href="http://example.com/admin/users">Users</a>
```

**Note**: I am making the assumption in this PR that the URL in the Torch NavBar will always **end** in the same value as the current URL, i.e. `.../admin/developer_user` or `.../admin/developer_user/` not `.../admin/developer_user#anchor`. It should however, handle query parameters fine if those were present for whatever reason.