### PR TITLE
Fix FilterView regex greediness

### DIFF
--- a/lib/torch/views/filter_view.ex
+++ b/lib/torch/views/filter_view.ex
@@ -306,7 +306,7 @@ defmodule Torch.FilterView do
 
     result =
       Enum.find(params || %{}, fn {param_name, _val} ->
-        String.match?(param_name, ~r/#{field}_(?:#{suffix_patterns})/)
+        String.match?(param_name, ~r/^#{field}_(?:#{suffix_patterns})/)
       end)
 
     if is_nil(result) do

--- a/test/torch/views/filter_view_test.exs
+++ b/test/torch/views/filter_view_test.exs
@@ -72,4 +72,39 @@ defmodule Torch.FilterViewTest do
     assert input_email_expected ==
              safe_to_string(Torch.FilterView.filter_string_input(:user, :email, params))
   end
+
+  test "param name does not greedily match" do
+    # * See GitHub PR 372: https://github.com/mojotech/torch/pull/372
+
+    params = %{
+      "filters" => [
+        "robot[board_serial_contains]",
+        "robot[serial_contains]",
+        "robot[other_serial_contains]"
+      ],
+      "robot" => %{
+        "board_serial_contains" => "0987654321",
+        "serial_contains" => "1234567890",
+        "other_serial_contains" => "qwertyuiop"
+      }
+    }
+
+    expected =
+      "<input id=\"robot_board_serial_contains\" name=\"robot[board_serial_contains]\" type=\"text\" value=\"0987654321\">"
+
+    assert expected ==
+             safe_to_string(Torch.FilterView.filter_string_input(:robot, :board_serial, params))
+
+    expected =
+      "<input id=\"robot_serial_contains\" name=\"robot[serial_contains]\" type=\"text\" value=\"1234567890\">"
+
+    assert expected ==
+             safe_to_string(Torch.FilterView.filter_string_input(:robot, :serial, params))
+
+    expected =
+      "<input id=\"robot_other_serial_contains\" name=\"robot[other_serial_contains]\" type=\"text\" value=\"qwertyuiop\">"
+
+    assert expected ==
+             safe_to_string(Torch.FilterView.filter_string_input(:robot, :other_serial, params))
+  end
 end


### PR DESCRIPTION
The issue can be exemplified at its simplest like this:

```elixir
true == String.match?("serial_contains", ~r/serial_(?:#{suffix_patterns})/)
true == String.match?("board_serial_contains", ~r/serial_(?:#{suffix_patterns})/)
```

So, the `serial_contains` field will never be selected because `board_serial` contains the string `serial`. Should probably write you a test, but maybe there's something I'm missing and this might cause regressions?