### PR TITLE
Add baseline Phoenix 1.7 support to Torch v4.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,6 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}", "test/{mix,torch}/**/*.{ex,exs}"],
   locals_without_parens: [
     # Phoenix
     plug: 2,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   mix_test:
     name: mix test (Elixir ${{matrix.elixir}} | OTP ${{matrix.otp}})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -20,18 +20,30 @@ jobs:
         include:
           - elixir: 1.12.x
             otp: 22.x
+          - elixir: 1.13.x
+            otp: 22.x
           - elixir: 1.12.x
+            otp: 23.x
+          - elixir: 1.13.x
             otp: 23.x
           - elixir: 1.12.x
             otp: 24.x
+          - elixir: 1.13.x
+            otp: 24.x
+          - elixir: 1.14.x
+            otp: 23.x
+          - elixir: 1.14.x
+            otp: 24.x
+          - elixir: 1.14.x
+            otp: 25.x
 
     services:
       db:
-        image: postgres:10.1-alpine
+        image: postgres:latest
         env:
-          POSTGRES_USER: postgres
           POSTGRES_DB: example_test
-          POSTGRES_PASSWORD: ""
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready
@@ -42,6 +54,7 @@ jobs:
     env:
       MIX_ENV: test
       DATABASE_POSTGRESQL_USERNAME: postgres
+      DATABASE_POSTGRESQL_PASSWORD: postgres
       PGHOST: postgres
       PGUSER: postgres
 
@@ -52,7 +65,7 @@ jobs:
           node-version: '14'
           cache: 'npm'
           cache-dependency-path: assets/package-lock.json
-      - uses: erlef/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/v3.yml
+++ b/.github/workflows/v3.yml
@@ -2,10 +2,12 @@ name: Torch v3 CI
 
 on:
   pull_request:
-    branches: [v3]
+    branches: [v1, v2, v3]
     types: [opened, edited, reopened, synchronize]
   push:
     branches: [v3]
+    tags:
+      - v[1-3].[0-9]+.[0-9]+
 
 jobs:
   mix_test:

--- a/.github/workflows/v4.yml
+++ b/.github/workflows/v4.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   mix_test:
     name: mix test (Elixir ${{matrix.elixir}} | OTP ${{matrix.otp}})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -20,10 +20,18 @@ jobs:
         include:
           - elixir: 1.12.x
             otp: 22.x
+          - elixir: 1.13.x
+            otp: 22.x
           - elixir: 1.12.x
+            otp: 23.x
+          - elixir: 1.13.x
             otp: 23.x
           - elixir: 1.12.x
             otp: 24.x
+          - elixir: 1.13.x
+            otp: 24.x
+          - elixir: 1.14.x
+            otp: 23.x
           - elixir: 1.14.x
             otp: 24.x
           - elixir: 1.14.x
@@ -46,6 +54,7 @@ jobs:
     env:
       MIX_ENV: test
       DATABASE_POSTGRESQL_USERNAME: postgres
+      DATABASE_POSTGRESQL_PASSWORD: postgres
       PGHOST: postgres
       PGUSER: postgres
 
@@ -56,7 +65,7 @@ jobs:
           node-version: '14'
           cache: 'npm'
           cache-dependency-path: assets/package-lock.json
-      - uses: erlef/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/v4.yml
+++ b/.github/workflows/v4.yml
@@ -2,12 +2,12 @@ name: Torch CI
 
 on:
   pull_request:
-    branches: [master, main, v5]
+    branches: [v4]
     types: [opened, edited, reopened, synchronize]
   push:
-    branches: [master, main, v5]
+    branches: [v4]
     tags:
-      - v[5-9].[0-9]+.[0-9]+
+      - v4.[0-9]+.[0-9]+
 
 jobs:
   mix_test:

--- a/.github/workflows/v4.yml
+++ b/.github/workflows/v4.yml
@@ -1,4 +1,4 @@
-name: Torch CI
+name: Torch v4 CI
 
 on:
   pull_request:
@@ -24,14 +24,18 @@ jobs:
             otp: 23.x
           - elixir: 1.12.x
             otp: 24.x
+          - elixir: 1.14.x
+            otp: 24.x
+          - elixir: 1.14.x
+            otp: 25.x
 
     services:
       db:
-        image: postgres:10.1-alpine
+        image: postgres:latest
         env:
-          POSTGRES_USER: postgres
           POSTGRES_DB: example_test
-          POSTGRES_PASSWORD: ""
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready

--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@
 
 # Torch
 
-> This version of Torch (4.x) only supports Phoenix 1.6 and above.
+> This version of Torch (4.x) only fully supports Phoenix 1.6 and minimally runs on Phoenix 1.7.
+
+> Installations that use Torch v4 prior to Phoenix 1.7,
+> can also continue to use Torch v4 in a limited manner - new torch models and views cannot be generated for
+> Phoenix 1.7, but previously generated torch templates will continue to function.  For users running Phoenix 1.7
+> and newer, please upgrade to Torch v5 to generate new Torch templates and take advantage of future Torch updates.
+> If using Torch v4 with Phoenix 1.7, you will need to manually add `{:phoenix_view, "~> 2.0"}` to your `deps` in `mix.exs`.
+
 > See [v3.0](https://github.com/mojotech/torch/tree/v3) if you need support for Phoenix 1.5 and below
 
 
@@ -32,7 +39,7 @@ To install Torch, perform the following steps:
 ```elixir
 def deps do
   [
-    {:torch, "~> 4.0"}
+    {:torch, "~> 4.3"}
   ]
 end
 ```

--- a/lib/mix/tasks/torch.gen.html.ex
+++ b/lib/mix/tasks/torch.gen.html.ex
@@ -21,6 +21,14 @@ defmodule Mix.Tasks.Torch.Gen.Html do
 
     Mix.Torch.ensure_phoenix_is_loaded!("torch.gen.html")
 
+    phoenix_version = :phoenix |> Application.spec(:vsn) |> to_string()
+
+    if Version.match?(phoenix_version, ">= 1.7.0") do
+      Mix.raise(
+        "Torch v4 Mix tasks will not run on Phoenix 1.7+.  Please upgrade to Torch v5 or newer."
+      )
+    end
+
     template_format =
       if format == "slime" do
         format

--- a/lib/mix/tasks/torch.install.ex
+++ b/lib/mix/tasks/torch.install.ex
@@ -29,7 +29,13 @@ defmodule Mix.Tasks.Torch.Install do
 
     Mix.Torch.ensure_phoenix_is_loaded!("torch.install")
 
-    phoenix_version = Application.spec(:phoenix, :vsn)
+    phoenix_version = :phoenix |> Application.spec(:vsn) |> to_string()
+
+    if Version.match?(phoenix_version, ">= 1.7.0") do
+      Mix.raise(
+        "Torch v4 Mix tasks will not run on Phoenix 1.7+.  Please upgrade to Torch v5 or newer."
+      )
+    end
 
     Mix.Torch.copy_from("priv/templates/#{format}", [
       {template_file(phoenix_version, format),

--- a/lib/mix/tasks/torch.uninstall.ex
+++ b/lib/mix/tasks/torch.uninstall.ex
@@ -14,6 +14,16 @@ defmodule Mix.Tasks.Torch.Uninstall do
 
     %{format: format, otp_app: otp_app} = Mix.Torch.parse_config!("torch.uninstall", args)
 
+    Mix.Torch.ensure_phoenix_is_loaded!("torch.uninstall")
+
+    phoenix_version = :phoenix |> Application.spec(:vsn) |> to_string()
+
+    if Version.match?(phoenix_version, ">= 1.7.0") do
+      Mix.raise(
+        "Torch v4 Mix tasks will not run on Phoenix 1.7+.  Please upgrade to Torch v5 or newer."
+      )
+    end
+
     paths = [
       "lib/#{otp_app}_web/templates/layout/torch.html.#{format}"
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Torch.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/mojotech/torch"
-  @version "4.2.1"
+  @version "4.3.0"
 
   def project do
     [
@@ -43,7 +43,7 @@ defmodule Torch.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:phoenix, "~> 1.6.0"},
+      {:phoenix, ">= 1.6.0 and < 1.8.0"},
       {:phoenix_html, "~> 3.0"},
       {:gettext, "~> 0.16"},
       {:scrivener_ecto, "~> 2.7.0"},


### PR DESCRIPTION
Mix tasks will not run for users using Phoenix 1.7+ and Torch 4, but existing Torch installations will still work after upgrading from Phoenix 1.6 to 1.7.  