### PR TITLE
Support filtering :id type fields

### DIFF
--- a/lib/torch/pagination.ex
+++ b/lib/torch/pagination.ex
@@ -157,7 +157,7 @@ defmodule Torch.Pagination do
   defp build_filter_config(model, schema_attrs) do
     schema_attrs
     |> Enum.reduce(
-      Map.from_keys(~w(date number text boolean)a, []),
+      Map.from_keys(~w(date number text boolean id)a, []),
       &collect_attributes_by_type(&1, model.__schema__(:type, &1), &2)
     )
     |> Enum.reduce([], &build_filtrex_configs/2)
@@ -173,7 +173,7 @@ defmodule Torch.Pagination do
     do: collection
 
   defp collect_attributes_by_type(attr, attr_type, collection)
-       when attr_type in [:integer, :number] do
+       when attr_type in [:integer, :number, :id] do
     Map.update(collection, :number, [attr], fn curr_value -> [attr | curr_value] end)
   end
 

--- a/test/torch/pagination_test.exs
+++ b/test/torch/pagination_test.exs
@@ -88,7 +88,7 @@ defmodule PaginationTest do
           assert ~w(body title) == Enum.sort(attr_keys)
 
         :number ->
-          assert ~w(view_count) == Enum.sort(attr_keys)
+          assert ~w(id view_count) == Enum.sort(attr_keys)
 
         :boolean ->
           assert ~w(archived) == Enum.sort(attr_keys)
@@ -105,7 +105,7 @@ defmodule PaginationTest do
           assert ~w(body title) == Enum.sort(attr_keys)
 
         :number ->
-          assert [] == attr_keys
+          assert ~w(id) == attr_keys
 
         :boolean ->
           assert [] == attr_keys
@@ -122,7 +122,7 @@ defmodule PaginationTest do
           assert [] == attr_keys
 
         :number ->
-          assert [] == attr_keys
+          assert ~w(id) == attr_keys
 
         :boolean ->
           assert [] == attr_keys


### PR DESCRIPTION
This change supports filtering for id type fields such as belongs_to.