### PR TITLE
Support filtering `id` type fields

### DIFF
--- a/lib/torch/pagination.ex
+++ b/lib/torch/pagination.ex
@@ -157,7 +157,7 @@ defmodule Torch.Pagination do
   defp build_filter_config(model, schema_attrs) do
     schema_attrs
     |> Enum.reduce(
-      Map.from_keys(~w(date number text boolean)a, []),
+      Map.from_keys(~w(date number text boolean id)a, []),
       &collect_attributes_by_type(&1, model.__schema__(:type, &1), &2)
     )
     |> Enum.reduce([], &build_filtrex_configs/2)
@@ -173,7 +173,7 @@ defmodule Torch.Pagination do
     do: collection
 
   defp collect_attributes_by_type(attr, attr_type, collection)
-       when attr_type in [:integer, :number] do
+       when attr_type in [:integer, :number, :id] do
     Map.update(collection, :number, [attr], fn curr_value -> [attr | curr_value] end)
   end
 

--- a/test/torch/pagination_test.exs
+++ b/test/torch/pagination_test.exs
@@ -38,6 +38,16 @@ defmodule NoAttrsMockModel do
   end
 end
 
+defmodule AssocMockModel do
+  use Ecto.Schema
+
+  schema "assoc_mocks" do
+    field(:title, :string)
+    field(:small_mock_id, :integer, references: SmallMockModel)
+    belongs_to(:mock, MockModel, foreign_key: :mock_id)
+  end
+end
+
 defmodule MockContext do
   import Ecto.Query, warn: false
 
@@ -59,6 +69,15 @@ defmodule MultiMockContext do
     repo: MockRepo,
     model: NoAttrsMockModel,
     name: :no_mocks
+end
+
+defmodule AssocMockContext do
+  import Ecto.Query, warn: false
+
+  use Torch.Pagination,
+    repo: MockRepo,
+    model: AssocMockModel,
+    name: :assoc_mocks
 end
 
 defmodule PaginationTest do
@@ -88,7 +107,7 @@ defmodule PaginationTest do
           assert ~w(body title) == Enum.sort(attr_keys)
 
         :number ->
-          assert ~w(view_count) == Enum.sort(attr_keys)
+          assert ~w(id view_count) == Enum.sort(attr_keys)
 
         :boolean ->
           assert ~w(archived) == Enum.sort(attr_keys)
@@ -105,7 +124,7 @@ defmodule PaginationTest do
           assert ~w(body title) == Enum.sort(attr_keys)
 
         :number ->
-          assert [] == attr_keys
+          assert ~w(id) == attr_keys
 
         :boolean ->
           assert [] == attr_keys
@@ -122,7 +141,24 @@ defmodule PaginationTest do
           assert [] == attr_keys
 
         :number ->
+          assert ~w(id) == attr_keys
+
+        :boolean ->
           assert [] == attr_keys
+
+        :date ->
+          assert [] == attr_keys
+      end
+    end
+
+    for %Filtrex.Type.Config{type: t, keys: attr_keys} <-
+          AssocMockContext.filter_config(:assoc_mocks) do
+      case t do
+        :text ->
+          assert ~w(title) == Enum.sort(attr_keys)
+
+        :number ->
+          assert ~w(mock_id small_mock_id id) == attr_keys
 
         :boolean ->
           assert [] == attr_keys


### PR DESCRIPTION
This will allow using filters such as `filter_assoc_select/4`.

Ecto uses integer values for the `id` type in a schema.

The `uuid` type in Ecto is a string value, and is not included in the scope of this PR change.

[close #429]