### PR TITLE
Some cleanup of tests and test artifacts

### DIFF
--- a/test/support/apps/phx1_7/bin/test
+++ b/test/support/apps/phx1_7/bin/test
@@ -13,6 +13,10 @@ function cleanup() {
     rm -rf lib/phx1_7_web/views/post_view.ex
     rm -rf test/phx1_7_web/controllers/post_controller_test.exs
     rm -rf test/support/fixtures/
+    rm -rf lib/phx1_7_web/components/layouts/torch.html.heex
+    rm -rf lib/phx1_7_web/controllers/post_html.ex
+    rm -rf lib/phx1_7_web/controllers/post_html/
+
     patch -i ../../patches/install-torch.diff -p 1 -R
     patch -i ../../patches/install-route.diff -p 1 -R
 }

--- a/test/support/apps/phx1_7/bin/test
+++ b/test/support/apps/phx1_7/bin/test
@@ -26,8 +26,8 @@ mix deps.get || { cleanup; echo 'Dependencies could not be fetched!'; exit 1; }
 MIX_ENV=test mix ecto.drop || { cleanup; echo 'Database could not be dropped'; exit 1; }
 MIX_ENV=test mix torch.install || { cleanup; echo 'Torch could not be installed!'; exit 1; }
 MIX_ENV=test mix torch.gen.html Blog Post posts title:string published:boolean published_at:datetime views:integer || { echo 'Torch files not generated!'; exit 1; }
-MIX_ENV=test mix ecto.setup ||  { cleanup; echo 'Torch database could not be setup!'; exit 1; }
 patch -i ../../patches/install-route.diff -p 1
+MIX_ENV=test mix ecto.setup ||  { cleanup; echo 'Torch database could not be setup!'; exit 1; }
 MIX_ENV=test mix test || { echo 'Tests failed!'; cleanup; exit 1; }
 
 # Ensure that put_root_layout is used by default on > Phx 1.5


### PR DESCRIPTION
Two things here:
1. Some warnings were generated during tests due to the sequencing of when the new routes for posts pages were added. Those have been fixed by shifting the patch for the routes higher up in the test sequence.
2. Some files generated during the support tests were not cleaned up appropriately after test run. Adding some additional `rm -rf` lines to the cleanup function tidies things up neatly.