### PR TITLE
Add ex_doc links to Phoenix.HTML.Form

### DIFF
--- a/lib/torch/component.ex
+++ b/lib/torch/component.ex
@@ -9,9 +9,9 @@ defmodule Torch.Component do
   @doc """
   Renders a Torch form input with label and error messages.
 
-  A `%Phoenix.HTML.Form{}` and field name may be passed to the input
-  to build input names and error messages, or all the attributes and
-  errors may be passed explicitly.
+  A `%Phoenix.HTML.Form{}` (see `Phoenix.HTML.Form`) and field name may be
+  passed to the input to build input names and error messages, or all the
+  attributes and errors may be passed explicitly.
 
   ## Examples
 
@@ -36,7 +36,7 @@ defmodule Torch.Component do
   attr(:errors, :list, default: [])
   attr(:checked, :boolean, doc: "the checked flag for checkbox inputs")
   attr(:prompt, :string, default: nil, doc: "the prompt for select inputs")
-  attr(:options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2")
+  attr(:options, :list, doc: "the options to pass to `Phoenix.HTML.Form.options_for_select/2`")
   attr(:multiple, :boolean, default: false, doc: "the multiple flag for select inputs")
 
   attr(:rest, :global,


### PR DESCRIPTION
Adds some helpful links to the `Torch.Component.torch_input` docs.

This PR:
![Screenshot 2024-08-21 08-06-24@2x](https://github.com/user-attachments/assets/91800be7-6b9a-45fd-bbfc-74843409f568)

Prod:
![Screenshot 2024-08-21 08-05-00@2x](https://github.com/user-attachments/assets/92c2d0ff-3f67-48fe-a156-db76b7047f2a)
