### PR TITLE
Fix compilation warning on Elixir 1.18

### DIFF
--- a/lib/torch/pagination.ex
+++ b/lib/torch/pagination.ex
@@ -93,7 +93,7 @@ defmodule Torch.Pagination do
     schema_attrs = model.__schema__(:query_fields)
     schema_filter_config = build_filter_config(model, schema_attrs)
 
-    quote do
+    quote(generated: true) do
       def unquote(:"paginate_#{name}")(params \\ %{}) do
         params =
           params


### PR DESCRIPTION
Fix compilation warning for some schemas on Elixir 1.18. Fixes this warning:
```
    warning: comparison between distinct types found:

        Photos.PhotoSchema.__schema__(:type, capture) == :boolean

    given types:

        dynamic(:id or :naive_datetime_usec or nil or :string or :utc_datetime_usec) == :boolean

    where "capture" was given the type:

        # type: dynamic()
        # from: lib/photos/photos.ex:7
        capture

    While Elixir can compare across all types, you are comparing across types which are always disjoint, and the result is either always true or always false

    typing violation found at:
    │
  7 │   use Torch.Pagination,
    │   ~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/photos/photos.ex:7: Cute.Photos.paginate_photos/1
```
This occurred when my schema didn't have a boolean field:
```elixir
defmodule Photos.PhotoSchema do
  use Ecto.Schema

  schema "photos" do
    field :name, :string
    field :path, :string
    field :comments, :string
    field :last_viewed_at, :naive_datetime_usec

    timestamps(type: :utc_datetime_usec)
  end
end
```
and using pagination like:
```elixir
use Torch.Pagination,
  repo: Photos.Repo,
  model: Photos.PhotoSchema,
  name: :photos
```

I fix the error by indicating to Elixir that the code has been generated, which avoids this type error since depending on the module, the check will sometimes succeed (i.e. if you add a `field :enabled, :boolean` to the schema). I'm not sure about docs but I found this solution from:
https://elixirforum.com/t/elixir-v1-18-0-rc-0-released/68015/11?u=axelson