### PR TITLE
Add file as a type for torch_input

### DIFF
--- a/lib/torch/component.ex
+++ b/lib/torch/component.ex
@@ -22,7 +22,7 @@ defmodule Torch.Component do
 
   attr(:type, :string,
     default: "text",
-    values: ~w(number checkbox textarea date datetime time datetime-local select text string)
+    values: ~w(number checkbox textarea date datetime time datetime-local select text string file)
   )
 
   attr(:value, :any)


### PR DESCRIPTION
Fixes a compilation warning in my app:
```
Compiling 25 files (.ex)
    warning: attribute "type" in component Torch.Component.torch_input/1 must be one of ["number", "checkbox", "textarea", "date", "datetime", "time", "datetime-local", "select", "text", "string"], got: "file"
    │
 12 │     <.torch_input label="Photo" field={f[:photo]} type="file" />
    │     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/my_app_web/admin/photo_schema_html/photo_schema_form.html.heex:12: (file)
```
The input works in my app for selecting a file.

Although should we also add all the file types listed in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types?