### PR TITLE
Fix elixir 1.18 compilation warnings

### DIFF
--- a/lib/torch/views/filter_view.ex
+++ b/lib/torch/views/filter_view.ex
@@ -272,14 +272,6 @@ defmodule Torch.FilterView do
     tag(:input, type: "text", class: "datepicker #{class}", name: name, value: value)
   end
 
-  defp find_param(params, field, :string) do
-    do_find_param(params, field, "contains")
-  end
-
-  defp find_param(params, field, :number) do
-    do_find_param(params, field, "equals")
-  end
-
   defp find_param(params, field, :select) do
     do_find_param(params, field, ~w(contains equals))
   end


### PR DESCRIPTION
Elixir 1.18 starts using the nascent type system to detect more compilation warnings. There are the warnings that occur when running Torch under Elixir 1.18:
```
> mix compile --all-warnings --warnings-as-errors
     warning: this clause of defp find_param/3 is never used
     │
 275 │   defp find_param(params, field, :string) do
     │        ~
     │
     └─ lib/torch/views/filter_view.ex:275:8: Torch.FilterView.find_param/3

     warning: this clause of defp find_param/3 is never used
     │
 279 │   defp find_param(params, field, :number) do
     │        ~
     │
     └─ lib/torch/views/filter_view.ex:279:8: Torch.FilterView.find_param/3
```
Looking at the code those function clauses indeed are not called so they can be safely removed.