### PR TITLE
UUID field

### DIFF
--- a/lib/torch/pagination.ex
+++ b/lib/torch/pagination.ex
@@ -159,7 +159,7 @@ defmodule Torch.Pagination do
   defp build_filter_config(model, schema_attrs) do
     schema_attrs
     |> Enum.reduce(
-      Map.from_keys(~w(date number text boolean id)a, []),
+      Map.from_keys(~w(date number text boolean id binary_id)a, []),
       &collect_attributes_by_type(&1, model.__schema__(:type, &1), &2)
     )
     |> Enum.reduce([], &build_filtrex_configs/2)
@@ -194,7 +194,7 @@ defmodule Torch.Pagination do
   end
 
   defp collect_attributes_by_type(attr, :binary_id, collection) do
-    Map.update(collection, :id, [attr], fn curr_value -> [attr | curr_value] end)
+    Map.update(collection, :binary_id, [attr], fn curr_value -> [attr | curr_value] end)
   end
 
   defp collect_attributes_by_type(_attr, _attr_type, collection), do: collection

--- a/lib/torch/pagination.ex
+++ b/lib/torch/pagination.ex
@@ -193,6 +193,10 @@ defmodule Torch.Pagination do
     Map.update(collection, :text, [attr], fn curr_value -> [attr | curr_value] end)
   end
 
+  defp collect_attributes_by_type(attr, :binary_id, collection) do
+    Map.update(collection, :id, [attr], fn curr_value -> [attr | curr_value] end)
+  end
+
   defp collect_attributes_by_type(_attr, _attr_type, collection), do: collection
 
   defp build_filtrex_configs({:date, attrs_list}, configs),
@@ -206,6 +210,9 @@ defmodule Torch.Pagination do
 
   defp build_filtrex_configs({:boolean, attrs_list}, configs),
     do: add_filtrex_config(configs, :boolean, attrs_list)
+
+  defp build_filtrex_configs({:binary_id, attrs_list}, configs),
+    do: add_filtrex_config(configs, :binary_id, attrs_list)
 
   defp build_filtrex_configs(_, configs), do: configs
 

--- a/lib/torch/views/filter_view.ex
+++ b/lib/torch/views/filter_view.ex
@@ -235,6 +235,25 @@ defmodule Torch.FilterView do
     select(prefix, :"#{field}_equals", opts, class: "boolean-type", value: value)
   end
 
+  @doc """
+  Generates a "equals" filter type select box for a given `uuid` field
+  ## Example
+      iex> params = %{"post" => %{"id_equals" => "test"}}
+      ...> filter_uuid(:post, :id, params) |> safe_to_string()
+      "<select class=\\"filter-type\\" id=\\"filters_\\" name=\\"filters[]\\"><option selected value=\\"post[id_equals]\\">Equals</option></select>"
+  """
+  @spec filter_uuid(prefix, field, map) :: Phoenix.HTML.safe()
+  def filter_uuid(prefix, field, params) do
+    prefix_str = to_string(prefix)
+    {selected, _value} = find_param(params[prefix_str], field, :uuid_select)
+
+    opts = [
+      {message("Equals"), "#{prefix}[#{field}_equals]"}
+    ]
+
+    select(:filters, "", opts, class: "filter-type", value: "#{prefix}[#{selected}]")
+  end
+
   defp torch_date_input(name, value) do
     tag(
       :input,
@@ -282,6 +301,10 @@ defmodule Torch.FilterView do
 
   defp find_param(params, field, :number_select) do
     do_find_param(params, field, ~w(equals greater_than greater_than_or less_than))
+  end
+
+  defp find_param(params, field, :uuid_select) do
+    do_find_param(params, field, "equals")
   end
 
   defp do_find_param(params, field, comparison) when is_binary(comparison) do

--- a/lib/torch/views/filter_view.ex
+++ b/lib/torch/views/filter_view.ex
@@ -245,7 +245,7 @@ defmodule Torch.FilterView do
   @spec filter_uuid(prefix, field, map) :: Phoenix.HTML.safe()
   def filter_uuid(prefix, field, params) do
     prefix_str = to_string(prefix)
-    {selected, _value} = find_param(params[prefix_str], field, :uuid_select)
+    {selected, _value} = find_param(params[prefix_str], field, :equals)
 
     opts = [
       {message("Equals"), "#{prefix}[#{field}_equals]"}
@@ -303,7 +303,7 @@ defmodule Torch.FilterView do
     do_find_param(params, field, ~w(equals greater_than greater_than_or less_than))
   end
 
-  defp find_param(params, field, :uuid_select) do
+  defp find_param(params, field, :equals) do
     do_find_param(params, field, "equals")
   end
 

--- a/priv/templates/phx.gen.html/index.html.heex
+++ b/priv/templates/phx.gen.html/index.html.heex
@@ -34,6 +34,13 @@
             <%%= filter_number_input(:<%= schema.singular %>, :<%= key %>, @conn.params) %>
           </div>
         <% end %>
+        <%= for {key, type} <- schema.attrs, type in [:binary_id] do %>
+          <div class="field">
+            <label><%= Phoenix.Naming.humanize(Atom.to_string(key)) %></label>
+            <%%= filter_uuid(:<%= schema.singular %>, :<%= key %>, @conn.params) %>
+            <%%= filter_string_input(:<%= schema.singular %>, :<%= key %>, @conn.params) %>
+          </div>
+        <% end %>
         <button type="submit" class="torch-button">Search</button>
         <%%= link "Clear Filters", to: ~p"<%=  schema.route_prefix %>" %>
       <%% end %>

--- a/priv/templates/phx.gen.html/index.html.heex
+++ b/priv/templates/phx.gen.html/index.html.heex
@@ -38,7 +38,6 @@
           <div class="field">
             <label><%= Phoenix.Naming.humanize(Atom.to_string(key)) %></label>
             <%%= filter_uuid(:<%= schema.singular %>, :<%= key %>, @conn.params) %>
-            <%%= filter_string_input(:<%= schema.singular %>, :<%= key %>, @conn.params) %>
           </div>
         <% end %>
         <button type="submit" class="torch-button">Search</button>

--- a/priv/templates/phx.gen.html/index.html.heex
+++ b/priv/templates/phx.gen.html/index.html.heex
@@ -38,6 +38,7 @@
           <div class="field">
             <label><%= Phoenix.Naming.humanize(Atom.to_string(key)) %></label>
             <%%= filter_uuid(:<%= schema.singular %>, :<%= key %>, @conn.params) %>
+            <%%= filter_string_input(:<%= schema.singular %>, :<%= key %>, @conn.params) %>
           </div>
         <% end %>
         <button type="submit" class="torch-button">Search</button>

--- a/test/torch/pagination_test.exs
+++ b/test/torch/pagination_test.exs
@@ -95,9 +95,9 @@ defmodule PaginationTest do
   end
 
   test "Ensure we have Fitrex configuration for each key type" do
-    assert 4 == length(MockContext.filter_config(:mocks))
-    assert 4 == length(MultiMockContext.filter_config(:small_mocks))
-    assert 4 == length(MultiMockContext.filter_config(:no_mocks))
+    assert 5 == length(MockContext.filter_config(:mocks))
+    assert 5 == length(MultiMockContext.filter_config(:small_mocks))
+    assert 5 == length(MultiMockContext.filter_config(:no_mocks))
   end
 
   test "ensure proper attributes list for filter types" do
@@ -114,6 +114,9 @@ defmodule PaginationTest do
 
         :date ->
           assert ~w(inserted_at published_at updated_at) == Enum.sort(attr_keys)
+
+        :binary_id ->
+          assert ~w(uuid) == Enum.sort(attr_keys)
       end
     end
 
@@ -130,6 +133,9 @@ defmodule PaginationTest do
           assert [] == attr_keys
 
         :date ->
+          assert [] == attr_keys
+
+        :binary_id ->
           assert [] == attr_keys
       end
     end
@@ -148,6 +154,9 @@ defmodule PaginationTest do
 
         :date ->
           assert [] == attr_keys
+
+        :binary_id ->
+          assert [] == attr_keys
       end
     end
 
@@ -164,6 +173,9 @@ defmodule PaginationTest do
           assert [] == attr_keys
 
         :date ->
+          assert [] == attr_keys
+
+        :binary_id ->
           assert [] == attr_keys
       end
     end

--- a/test/torch/views/filter_view_test.exs
+++ b/test/torch/views/filter_view_test.exs
@@ -129,5 +129,11 @@ defmodule Torch.FilterViewTest do
       "<select class=\"filter-type\" id=\"filters_\" name=\"filters[]\"><option selected value=\"post[id_equals]\">Equals</option></select>"
 
     assert expected == safe_to_string(Torch.FilterView.filter_uuid(:post, :id, params))
+
+    input_expected =
+      "<input id=\"post_id_equals\" name=\"post[id_equals]\" type=\"text\" value=\"#{uuid}\">"
+
+    assert input_expected ==
+             safe_to_string(Torch.FilterView.filter_string_input(:post, :id, params))
   end
 end

--- a/test/torch/views/filter_view_test.exs
+++ b/test/torch/views/filter_view_test.exs
@@ -129,11 +129,5 @@ defmodule Torch.FilterViewTest do
       "<select class=\"filter-type\" id=\"filters_\" name=\"filters[]\"><option selected value=\"post[id_equals]\">Equals</option></select>"
 
     assert expected == safe_to_string(Torch.FilterView.filter_uuid(:post, :id, params))
-
-    input_expected =
-      "<input id=\"post_id_equals\" name=\"post[id_equals]\" type=\"text\" value=\"#{uuid}\">"
-
-    assert input_expected ==
-             safe_to_string(Torch.FilterView.filter_string_input(:post, :id, params))
   end
 end

--- a/test/torch/views/filter_view_test.exs
+++ b/test/torch/views/filter_view_test.exs
@@ -107,4 +107,33 @@ defmodule Torch.FilterViewTest do
     assert expected ==
              safe_to_string(Torch.FilterView.filter_string_input(:robot, :other_serial, params))
   end
+
+  test "filter uuid_select option selects a uuid" do
+    expected =
+      "<select class=\"filter-type\" id=\"filters_\" name=\"filters[]\"><option selected value=\"post[id_equals]\">Equals</option></select>"
+
+    assert expected == safe_to_string(Torch.FilterView.filter_uuid(:post, :id, %{}))
+
+    uuid = "3e03842b-0bde-471b-8825-24768ef6fbc2"
+
+    params = %{
+      "filters" => [
+        "post[id_equals]"
+      ],
+      "post" => %{
+        "id_equals" => uuid
+      }
+    }
+
+    expected =
+      "<select class=\"filter-type\" id=\"filters_\" name=\"filters[]\"><option selected value=\"post[id_equals]\">Equals</option></select>"
+
+    assert expected == safe_to_string(Torch.FilterView.filter_uuid(:post, :id, params))
+
+    input_expected =
+      "<input id=\"post_id_equals\" name=\"post[id_equals]\" type=\"text\" value=\"#{uuid}\">"
+
+    assert input_expected ==
+             safe_to_string(Torch.FilterView.filter_string_input(:post, :id, params))
+  end
 end


### PR DESCRIPTION
Add support for the binary_id (uuid) field. Aims to close #256 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for filtering UUID fields in pagination and filter forms.
  - Introduced a new filter input for UUID fields, allowing users to filter by exact match.
- **Bug Fixes**
  - Improved filter form templates to include options for UUID fields.
- **Tests**
  - Added tests to ensure correct rendering and selection of the UUID filter option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->